### PR TITLE
fix：修复了清除统计数据但是控制面板和dps趋势图例不会清除的问题

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -589,10 +589,20 @@
             if (chart && typeof chart.setOption === 'function') {
                 chart.setOption({
                     series: [],
+                    legend: {
+                        data: [],
+                        selected: {}
+                    },
                     xAxis: {
                         data: []
                     }
                 });
+            }
+            
+            // 清空控制面板中的用户控制项
+            const userControlsList = document.getElementById('userControlsList');
+            if (userControlsList) {
+                userControlsList.innerHTML = '';
             }
             
             fetchDataAndUpdateTables();


### PR DESCRIPTION
### 主要修改

- 修复了清除统计数据，但是选择玩家展示面板不会清除的问题
- 修复了清除统计数据，但是dps折线图的图例不会清除的问题