### PR TITLE
fix: 修复表头固定位置不准确的问题，新增兼容窗口尺寸变化的情况 #44

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2693,9 +2693,9 @@
         function updateTableStickyHeader(){
             const damageTable = document.getElementById('damageTable');
             const damageTableRows = damageTable.querySelectorAll('tr');
-            damageTableRows.forEach((row, index) => {
-                const height = row.offsetTop
-                row.style.setProperty('--th-top', `${index * height}px`);
+            damageTableRows.forEach((row) => {
+                const top = row.offsetTop
+                row.style.setProperty('--th-top', `${top}px`);
             });
         }
         window.addEventListener('resize', updateTableStickyHeader);

--- a/public/index.html
+++ b/public/index.html
@@ -2690,14 +2690,17 @@
         }
     </script>
     <script>
-        window.onload = function(){
-        const damageTable = document.getElementById('damageTable');
-        const damageTableRows = damageTable.querySelectorAll('tr');
-        damageTableRows.forEach((row, index) => {
-                const height = row.offsetHeight;
+        function updateTableStickyHeader(){
+            const damageTable = document.getElementById('damageTable');
+            const damageTableRows = damageTable.querySelectorAll('tr');
+            damageTableRows.forEach((row, index) => {
+                const prevRow = index > 0 ? damageTableRows[index - 1] : null;
+                const height = prevRow ? prevRow.offsetHeight : 0;
                 row.style.setProperty('--th-top', `${index * height}px`);
             });
         }
+        window.addEventListener('resize', updateTableStickyHeader);
+        document.addEventListener('DOMContentLoaded', updateTableStickyHeader);
     </script>
 </body>
 

--- a/public/index.html
+++ b/public/index.html
@@ -2694,8 +2694,7 @@
             const damageTable = document.getElementById('damageTable');
             const damageTableRows = damageTable.querySelectorAll('tr');
             damageTableRows.forEach((row, index) => {
-                const prevRow = index > 0 ? damageTableRows[index - 1] : null;
-                const height = prevRow ? prevRow.offsetHeight : 0;
+                const height = row.offsetTop
                 row.style.setProperty('--th-top', `${index * height}px`);
             });
         }


### PR DESCRIPTION
针对之前的PR：#44 
以及现有的Issue：#49

修复以下问题：
 - 表格表头位置不符合预期，错位
 - 坐标计算方式不准确，不能适应多行表头的情况