### PR TITLE
fix: 修复编译后exe无法访问public目录问题

### DIFF
--- a/server.js
+++ b/server.js
@@ -758,7 +758,7 @@ async function main() {
     //express 和 socket.io 设置
     app.use(cors());
     app.use(express.json()); // 解析JSON请求体
-    app.use(express.static(path.join(__dirname, 'public'))); // 静态文件服务
+    app.use(express.static(path.join(process.cwd(), 'public'))); // 静态文件服务
     const server = http.createServer(app);
     const io = new Server(server, {
         cors: {


### PR DESCRIPTION
将绝对路径 __dirname 替换为当前运行路径 process.cwd()