### PR TITLE
feat: Customize table content display

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -809,6 +809,140 @@
                 gap: 10px;
                 align-items: center;
                 justify-content: center;
+                flex-wrap: wrap;
+            }
+
+            /* 列设置弹窗样式 */
+            .column-settings-modal {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                background: rgba(0, 0, 0, 0.5);
+                display: none;
+                justify-content: center;
+                align-items: center;
+                z-index: 1000;
+            }
+
+            .column-settings-content {
+                background: white;
+                padding: 20px;
+                border-radius: 8px;
+                width: 90%;
+                max-width: 600px;
+                max-height: 80vh;
+                overflow-y: auto;
+                box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+            }
+
+            .column-settings-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                margin-bottom: 20px;
+                border-bottom: 2px solid #f0f0f0;
+                padding-bottom: 10px;
+            }
+
+            .column-settings-title {
+                font-size: 18px;
+                font-weight: bold;
+                color: #333;
+            }
+
+            .close-btn {
+                background: none;
+                border: none;
+                font-size: 24px;
+                cursor: pointer;
+                color: #666;
+                padding: 0;
+                width: 30px;
+                height: 30px;
+                border-radius: 50%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+            }
+
+            .close-btn:hover {
+                background: #f0f0f0;
+                color: #333;
+            }
+
+            .column-group {
+                margin-bottom: 20px;
+            }
+
+            .column-group-title {
+                font-size: 16px;
+                font-weight: bold;
+                color: #333;
+                margin-bottom: 10px;
+                padding: 8px 0;
+                border-bottom: 1px solid #e0e0e0;
+            }
+
+            .column-options {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+                gap: 10px;
+            }
+
+            .column-option {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                padding: 8px;
+                border-radius: 4px;
+                transition: background-color 0.2s ease;
+            }
+
+            .column-option:hover {
+                background: #f5f5f5;
+            }
+
+            .column-option input[type="checkbox"] {
+                width: 16px;
+                height: 16px;
+                margin: 0;
+            }
+
+            .column-option label {
+                margin: 0;
+                cursor: pointer;
+                flex: 1;
+                font-size: 14px;
+            }
+
+            /* 暗色模式下的列设置样式 */
+            .dark-mode .column-settings-content {
+                background: #2d2d2d;
+                color: #cbd5e0;
+            }
+
+            .dark-mode .column-settings-title {
+                color: #cbd5e0;
+            }
+
+            .dark-mode .column-group-title {
+                color: #cbd5e0;
+                border-bottom-color: #555;
+            }
+
+            .dark-mode .column-option:hover {
+                background: #3a3a3a;
+            }
+
+            .dark-mode .close-btn {
+                color: #cbd5e0;
+            }
+
+            .dark-mode .close-btn:hover {
+                background: #3a3a3a;
+                color: #fff;
             }
 
             .data-group-button {
@@ -990,6 +1124,9 @@
                 <button id="damageGroupBtn" class="data-group-button active" onclick="toggleDataGroup('damage')">⚔️ 伤害&DPS</button>
                 <button id="healingGroupBtn" class="data-group-button" onclick="toggleDataGroup('healing')">❤️ 治疗&HPS</button>
                 <button id="allGroupBtn" class="data-group-button" onclick="toggleDataGroup('all')">📊 全部数据</button>
+                <button class="data-group-button" onclick="openColumnSettings()">
+                    ⚙️ 表格设置
+                </button>
             </div>
             <div class="table-container">
                 <table id="damageTable">
@@ -1824,6 +1961,10 @@
                     }
                 }
                 updateTableStickyHeader();
+                // 应用列显示设置
+                if (typeof applyColumnVisibility === 'function') {
+                    applyColumnVisibility();
+                }
             }
 
             async function fetchData() {
@@ -1971,6 +2112,11 @@
                     body.classList.add('simple-mode');
                     button.textContent = '📄 详细模式';
                     localStorage.setItem('simpleMode', 'true');
+                }
+
+                // 切换模式后需要重新应用列显示设置
+                if (typeof applyColumnVisibility === 'function') {
+                    applyColumnVisibility();
                 }
 
                 // 在暂停状态下，切换模式后需要重新渲染表格
@@ -2828,11 +2974,517 @@
 
             // 点击弹窗外部区域关闭弹窗
             window.onclick = function (event) {
-                const modal = document.getElementById('controlsModal');
-                if (event.target === modal) {
+                const controlsModal = document.getElementById('controlsModal');
+                const columnModal = document.getElementById('columnSettingsModal');
+                if (event.target === controlsModal) {
                     toggleControlsModal();
+                } else if (event.target === columnModal) {
+                    closeColumnSettings();
                 }
             };
+
+            // 列显示设置相关功能
+            let columnVisibility = {
+                uid: true,
+                nickname: true,
+                job: true,
+                score: true,
+                hp: true,
+                takenDamage: true,
+                critRate: true,
+                luckyRate: true,
+                totalDamage: true,
+                pureCrit: true,
+                pureLucky: true,
+                critLucky: true,
+                realtimeDps: true,
+                realtimeDpsMax: true,
+                dps: true,
+                totalHealing: true,
+                healingPureCrit: true,
+                healingPureLucky: true,
+                healingCritLucky: true,
+                realtimeHps: true,
+                realtimeHpsMax: true,
+                hps: true,
+                actions: true
+            };
+
+            // 从localStorage加载列显示设置
+            function loadColumnSettings() {
+                const saved = localStorage.getItem('columnVisibility');
+                if (saved) {
+                    columnVisibility = { ...columnVisibility, ...JSON.parse(saved) };
+                }
+                updateColumnCheckboxes();
+                applyColumnVisibility();
+            }
+
+            // 保存列显示设置到localStorage
+            function saveColumnSettings() {
+                localStorage.setItem('columnVisibility', JSON.stringify(columnVisibility));
+            }
+
+            // 更新复选框状态
+            function updateColumnCheckboxes() {
+                Object.keys(columnVisibility).forEach(column => {
+                    const checkbox = document.querySelector(`#col-${column}`);
+                    if (checkbox) {
+                        checkbox.checked = columnVisibility[column];
+                    }
+                });
+            }
+
+            // 打开列设置弹窗
+            function openColumnSettings() {
+                generateColumnSettingsContent();
+                document.getElementById('columnSettingsModal').style.display = 'flex';
+            }
+
+            // 关闭列设置弹窗
+            function closeColumnSettings() {
+                document.getElementById('columnSettingsModal').style.display = 'none';
+            }
+
+            // 动态生成列设置内容
+            function generateColumnSettingsContent() {
+                const modal = document.getElementById('columnSettingsModal');
+                const content = modal.querySelector('.column-settings-content');
+                
+                // 清除现有内容（保留标题）
+                const existingGroups = content.querySelectorAll('.column-group');
+                existingGroups.forEach(group => group.remove());
+
+                const isSimpleMode = document.body.classList.contains('simple-mode');
+
+                // 基础信息组
+                const baseGroup = createColumnGroup('🔰 基础信息', [
+                    { id: 'uid', label: '角色ID', column: 'uid' },
+                    { id: 'nickname', label: '角色昵称', column: 'nickname' },
+                    { id: 'job', label: '职业', column: 'job' },
+                    { id: 'score', label: '评分', column: 'score' },
+                    { id: 'hp', label: 'HP', column: 'hp' },
+                    { id: 'takenDamage', label: '承伤', column: 'takenDamage' },
+                    { id: 'critRate', label: '暴击率', column: 'critRate' },
+                    { id: 'luckyRate', label: '幸运率', column: 'luckyRate' }
+                ]);
+                content.appendChild(baseGroup);
+
+                // 根据当前数据组显示相应的列设置
+                if (currentDataGroup === 'damage' || currentDataGroup === 'all') {
+                    // 伤害数据组
+                    const damageOptions = [{ id: 'totalDamage', label: '总伤害', column: 'totalDamage' }];
+                    
+                    if (!isSimpleMode) {
+                        damageOptions.push(
+                            { id: 'pureCrit', label: '纯暴击', column: 'pureCrit' },
+                            { id: 'pureLucky', label: '纯幸运', column: 'pureLucky' },
+                            { id: 'critLucky', label: '暴击幸运', column: 'critLucky' }
+                        );
+                    }
+
+                    const damageGroup = createColumnGroup('⚔️ 伤害数据', damageOptions);
+                    content.appendChild(damageGroup);
+
+                    // DPS数据组
+                    const dpsGroup = createColumnGroup('⚡ DPS数据', [
+                        { id: 'realtimeDps', label: '瞬时DPS', column: 'realtimeDps' },
+                        { id: 'realtimeDpsMax', label: '最大瞬时', column: 'realtimeDpsMax' },
+                        { id: 'dps', label: '总DPS', column: 'dps' }
+                    ]);
+                    content.appendChild(dpsGroup);
+                }
+
+                if (currentDataGroup === 'healing' || currentDataGroup === 'all') {
+                    // 治疗数据组
+                    const healingOptions = [{ id: 'totalHealing', label: '总治疗', column: 'totalHealing' }];
+                    
+                    if (!isSimpleMode) {
+                        healingOptions.push(
+                            { id: 'healingPureCrit', label: '纯暴击', column: 'healingPureCrit' },
+                            { id: 'healingPureLucky', label: '纯幸运', column: 'healingPureLucky' },
+                            { id: 'healingCritLucky', label: '暴击幸运', column: 'healingCritLucky' }
+                        );
+                    }
+
+                    const healingGroup = createColumnGroup('❤️ 治疗数据', healingOptions);
+                    content.appendChild(healingGroup);
+
+                    // HPS数据组
+                    const hpsGroup = createColumnGroup('💚 HPS数据', [
+                        { id: 'realtimeHps', label: '瞬时HPS', column: 'realtimeHps' },
+                        { id: 'realtimeHpsMax', label: '最大瞬时', column: 'realtimeHpsMax' },
+                        { id: 'hps', label: '总HPS', column: 'hps' }
+                    ]);
+                    content.appendChild(hpsGroup);
+                }
+
+                // 其他组
+                const otherGroup = createColumnGroup('🔧 其他', [
+                    { id: 'actions', label: '操作', column: 'actions' }
+                ]);
+                content.appendChild(otherGroup);
+
+                // 重新绑定事件
+                initColumnSettings();
+            }
+
+            // 创建列设置组
+            function createColumnGroup(title, options) {
+                const group = document.createElement('div');
+                group.className = 'column-group';
+
+                const groupTitle = document.createElement('div');
+                groupTitle.className = 'column-group-title';
+                groupTitle.textContent = title;
+                group.appendChild(groupTitle);
+
+                const optionsContainer = document.createElement('div');
+                optionsContainer.className = 'column-options';
+
+                options.forEach(option => {
+                    const optionDiv = document.createElement('div');
+                    optionDiv.className = 'column-option';
+
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.id = `col-${option.id}`;
+                    checkbox.setAttribute('data-column', option.column);
+                    checkbox.checked = columnVisibility[option.column] || false;
+
+                    const label = document.createElement('label');
+                    label.setAttribute('for', `col-${option.id}`);
+                    label.textContent = option.label;
+
+                    optionDiv.appendChild(checkbox);
+                    optionDiv.appendChild(label);
+                    optionsContainer.appendChild(optionDiv);
+                });
+
+                group.appendChild(optionsContainer);
+                return group;
+            }
+
+            // 应用列显示设置
+            function applyColumnVisibility() {
+                const table = document.getElementById('damageTable');
+                if (!table) return;
+
+                // 基础信息列（rowspan=2）
+                const baseColumns = [
+                    { column: 'uid', selector: 'th[title="角色唯一标识符"]' },
+                    { column: 'nickname', selector: 'th[title="角色昵称/自定义昵称"]' },
+                    { column: 'job', selector: 'th[title="角色职业"]' },
+                    { column: 'score', selector: 'th[title="角色评分"]' },
+                    { column: 'hp', selector: 'th[title="角色血量"]' },
+                    { column: 'takenDamage', selector: 'th[title="角色在战斗中受到的伤害"]' },
+                    { column: 'critRate', selector: 'th[title="角色在战斗中的暴击触发率"]' },
+                    { column: 'luckyRate', selector: 'th[title="角色在战斗中的幸运触发率"]' },
+                ];
+
+                // 应用基础列的显示/隐藏
+                baseColumns.forEach(({ column, selector }) => {
+                    const isVisible = columnVisibility[column];
+                    const headerCell = table.querySelector(selector);
+                    if (headerCell) {
+                        if (isVisible) {
+                            headerCell.style.removeProperty('display');
+                        } else {
+                            headerCell.style.setProperty('display', 'none', 'important');
+                        }
+                    }
+                });
+
+                // 伤害相关列
+                const damageColumns = [
+                    { column: 'totalDamage', selector: 'th[title="角色在战斗中造成的总伤害"]' },
+                    { column: 'pureCrit', selector: 'th[title="角色在战斗中造成的非幸运的暴击伤害"]' },
+                    { column: 'pureLucky', selector: 'th[title="角色在战斗中造成的非暴击的幸运伤害"]' },
+                    { column: 'critLucky', selector: 'th[title="角色在战斗中造成的暴击的幸运伤害"]' }
+                ];
+
+                damageColumns.forEach(({ column, selector }) => {
+                    const isVisible = columnVisibility[column];
+                    const headerCell = table.querySelector(selector);
+                    if (headerCell) {
+                        if (isVisible) {
+                            headerCell.style.removeProperty('display');
+                        } else {
+                            headerCell.style.setProperty('display', 'none', 'important');
+                        }
+                    }
+                });
+
+                // DPS相关列
+                const dpsColumns = [
+                    { column: 'realtimeDps', selector: 'th[title="角色在战斗中的最近一秒造成的伤害"]' },
+                    { column: 'realtimeDpsMax', selector: 'th[title="角色在战斗中的最大瞬时DPS"]' },
+                    { column: 'dps', selector: 'th[title="角色在战斗中的总DPS（以第一次技能与最后一次技能之间的时间作为有效战斗时间计算）"]' }
+                ];
+
+                dpsColumns.forEach(({ column, selector }) => {
+                    const isVisible = columnVisibility[column];
+                    const headerCell = table.querySelector(selector);
+                    if (headerCell) {
+                        if (isVisible) {
+                            headerCell.style.removeProperty('display');
+                        } else {
+                            headerCell.style.setProperty('display', 'none', 'important');
+                        }
+                    }
+                });
+
+                // 治疗相关列
+                const healingColumns = [
+                    { column: 'totalHealing', selector: 'th[title="角色在战斗中造成的总治疗量"]' },
+                    { column: 'healingPureCrit', selector: 'th[title="角色在战斗中造成的非幸运的暴击治疗量"]' },
+                    { column: 'healingPureLucky', selector: 'th[title="角色在战斗中造成的非暴击的幸运治疗量"]' },
+                    { column: 'healingCritLucky', selector: 'th[title="角色在战斗中造成的暴击的幸运治疗量"]' }
+                ];
+
+                healingColumns.forEach(({ column, selector }) => {
+                    const isVisible = columnVisibility[column];
+                    const headerCell = table.querySelector(selector);
+                    if (headerCell) {
+                        if (isVisible) {
+                            headerCell.style.removeProperty('display');
+                        } else {
+                            headerCell.style.setProperty('display', 'none', 'important');
+                        }
+                    }
+                });
+
+                // HPS相关列
+                const hpsColumns = [
+                    { column: 'realtimeHps', selector: 'th[title="角色在战斗中的最近一秒造成的伤害和治疗量"]' },
+                    { column: 'realtimeHpsMax', selector: 'th[title="角色在战斗中的最大瞬时HPS"]' },
+                    { column: 'hps', selector: 'th[title="角色在战斗中的总HPS（以第一次技能与最后一次技能之间的时间作为有效战斗时间计算）"]' }
+                ];
+
+                hpsColumns.forEach(({ column, selector }) => {
+                    const isVisible = columnVisibility[column];
+                    const headerCell = table.querySelector(selector);
+                    if (headerCell) {
+                        if (isVisible) {
+                            headerCell.style.removeProperty('display');
+                        } else {
+                            headerCell.style.setProperty('display', 'none', 'important');
+                        }
+                    }
+                });
+
+                // 操作列
+                const actionsHeader = table.querySelector('th:last-child');
+                if (actionsHeader && actionsHeader.textContent.includes('操作')) {
+                    if (columnVisibility.actions) {
+                        actionsHeader.style.removeProperty('display');
+                    } else {
+                        actionsHeader.style.setProperty('display', 'none', 'important');
+                    }
+                }
+
+                // 应用表体单元格的显示/隐藏
+                applyBodyColumnVisibility();
+
+                // 更新colspan
+                updateColspan();
+            }
+
+            // 应用表体单元格的显示/隐藏
+            function applyBodyColumnVisibility() {
+                const table = document.getElementById('damageTable');
+                if (!table) return;
+
+                // 获取所有表体行
+                const rows = table.querySelectorAll('tbody tr');
+                
+                rows.forEach(row => {
+                    const cells = row.querySelectorAll('td');
+                    
+                    // 基础信息列 (0-7)
+                    const baseCols = ['uid', 'nickname', 'job', 'score', 'hp', 'takenDamage', 'critRate', 'luckyRate'];
+                    baseCols.forEach((col, index) => {
+                        if (cells[index]) {
+                            if (columnVisibility[col]) {
+                                cells[index].style.removeProperty('display');
+                            } else {
+                                cells[index].style.setProperty('display', 'none', 'important');
+                            }
+                        }
+                    });
+
+                    // 动态列需要根据当前数据组和简洁模式来确定位置
+                    let cellIndex = 8; // 从第9列开始
+
+                    // 处理伤害相关列
+                    if (currentDataGroup === 'damage' || currentDataGroup === 'all') {
+                        // 总伤害列
+                        if (cells[cellIndex]) {
+                            if (columnVisibility.totalDamage) {
+                                cells[cellIndex].style.removeProperty('display');
+                            } else {
+                                cells[cellIndex].style.setProperty('display', 'none', 'important');
+                            }
+                        }
+                        cellIndex++;
+
+                        // 详细伤害列（非简洁模式）
+                        if (!document.body.classList.contains('simple-mode')) {
+                            const detailCols = ['pureCrit', 'pureLucky', 'critLucky'];
+                            detailCols.forEach(col => {
+                                if (cells[cellIndex]) {
+                                    if (columnVisibility[col]) {
+                                        cells[cellIndex].style.removeProperty('display');
+                                    } else {
+                                        cells[cellIndex].style.setProperty('display', 'none', 'important');
+                                    }
+                                }
+                                cellIndex++;
+                            });
+                        }
+
+                        // DPS列
+                        const dpsCols = ['realtimeDps', 'realtimeDpsMax', 'dps'];
+                        dpsCols.forEach(col => {
+                            if (cells[cellIndex]) {
+                                if (columnVisibility[col]) {
+                                    cells[cellIndex].style.removeProperty('display');
+                                } else {
+                                    cells[cellIndex].style.setProperty('display', 'none', 'important');
+                                }
+                            }
+                            cellIndex++;
+                        });
+                    }
+
+                    // 处理治疗相关列
+                    if (currentDataGroup === 'healing' || currentDataGroup === 'all') {
+                        // 总治疗列
+                        if (cells[cellIndex]) {
+                            if (columnVisibility.totalHealing) {
+                                cells[cellIndex].style.removeProperty('display');
+                            } else {
+                                cells[cellIndex].style.setProperty('display', 'none', 'important');
+                            }
+                        }
+                        cellIndex++;
+
+                        // 详细治疗列（非简洁模式）
+                        if (!document.body.classList.contains('simple-mode')) {
+                            const healingDetailCols = ['healingPureCrit', 'healingPureLucky', 'healingCritLucky'];
+                            healingDetailCols.forEach(col => {
+                                if (cells[cellIndex]) {
+                                    if (columnVisibility[col]) {
+                                        cells[cellIndex].style.removeProperty('display');
+                                    } else {
+                                        cells[cellIndex].style.setProperty('display', 'none', 'important');
+                                    }
+                                }
+                                cellIndex++;
+                            });
+                        }
+
+                        // HPS列
+                        const hpsCols = ['realtimeHps', 'realtimeHpsMax', 'hps'];
+                        hpsCols.forEach(col => {
+                            if (cells[cellIndex]) {
+                                if (columnVisibility[col]) {
+                                    cells[cellIndex].style.removeProperty('display');
+                                } else {
+                                    cells[cellIndex].style.setProperty('display', 'none', 'important');
+                                }
+                            }
+                            cellIndex++;
+                        });
+                    }
+
+                    // 操作列（最后一列）
+                    const lastCell = cells[cells.length - 1];
+                    if (lastCell) {
+                        if (columnVisibility.actions) {
+                            lastCell.style.removeProperty('display');
+                        } else {
+                            lastCell.style.setProperty('display', 'none', 'important');
+                        }
+                    }
+                });
+            }
+
+            // 更新表头的colspan
+            function updateColspan() {
+                const table = document.getElementById('damageTable');
+                if (!table) return;
+
+                // 计算各组可见列数
+                const damageMainVisible = ['totalDamage', 'pureCrit', 'pureLucky', 'critLucky']
+                    .filter(col => columnVisibility[col]).length;
+                const dpsVisible = ['realtimeDps', 'realtimeDpsMax', 'dps']
+                    .filter(col => columnVisibility[col]).length;
+                const healingMainVisible = ['totalHealing', 'healingPureCrit', 'healingPureLucky', 'healingCritLucky']
+                    .filter(col => columnVisibility[col]).length;
+                const hpsVisible = ['realtimeHps', 'realtimeHpsMax', 'hps']
+                    .filter(col => columnVisibility[col]).length;
+
+                // 更新colspan
+                const damageMainHeader = table.querySelector('.damage-main-col');
+                const dpsHeader = table.querySelector('.dps-col');
+                const healingMainHeader = table.querySelector('.healing-main-col');
+                const hpsHeader = table.querySelector('.hps-col');
+
+                if (damageMainHeader) {
+                    if (damageMainVisible > 0) {
+                        damageMainHeader.setAttribute('colspan', damageMainVisible);
+                        damageMainHeader.style.removeProperty('display');
+                    } else {
+                        damageMainHeader.style.setProperty('display', 'none', 'important');
+                    }
+                }
+
+                if (dpsHeader) {
+                    if (dpsVisible > 0) {
+                        dpsHeader.setAttribute('colspan', dpsVisible);
+                        dpsHeader.style.removeProperty('display');
+                    } else {
+                        dpsHeader.style.setProperty('display', 'none', 'important');
+                    }
+                }
+
+                if (healingMainHeader) {
+                    if (healingMainVisible > 0) {
+                        healingMainHeader.setAttribute('colspan', healingMainVisible);
+                        healingMainHeader.style.removeProperty('display');
+                    } else {
+                        healingMainHeader.style.setProperty('display', 'none', 'important');
+                    }
+                }
+
+                if (hpsHeader) {
+                    if (hpsVisible > 0) {
+                        hpsHeader.setAttribute('colspan', hpsVisible);
+                        hpsHeader.style.removeProperty('display');
+                    } else {
+                        hpsHeader.style.setProperty('display', 'none', 'important');
+                    }
+                }
+            }
+
+            // 列设置复选框变化事件
+            function initColumnSettings() {
+                document.querySelectorAll('#columnSettingsModal input[type="checkbox"]').forEach(checkbox => {
+                    checkbox.addEventListener('change', function() {
+                        const column = this.getAttribute('data-column');
+                        columnVisibility[column] = this.checked;
+                        saveColumnSettings();
+                        applyColumnVisibility();
+                    });
+                });
+            }
+
+            // 初始化列设置
+            document.addEventListener('DOMContentLoaded', function() {
+                loadColumnSettings();
+                initColumnSettings();
+            });
 
             // 键盘ESC键关闭弹窗
             document.addEventListener('keydown', function (event) {
@@ -2908,5 +3560,17 @@
             window.addEventListener('resize', updateTableStickyHeader);
             document.addEventListener('DOMContentLoaded', updateTableStickyHeader);
         </script>
+
+        <!-- 列设置弹窗 -->
+        <div id="columnSettingsModal" class="column-settings-modal">
+            <div class="column-settings-content">
+                <div class="column-settings-header">
+                    <div class="column-settings-title">⚙️ 表格设置</div>
+                    <button class="close-btn" onclick="closeColumnSettings()">&times;</button>
+                </div>
+                
+                <!-- 内容将通过 JavaScript 动态生成 -->
+            </div>
+        </div>
     </body>
 </html>


### PR DESCRIPTION
### Main Change

Related to #65 

- Users can customize the columns they want to display

#### Default Simplified Mode

<img width="1718" height="1278" alt="image" src="https://github.com/user-attachments/assets/135fd411-dd77-40a6-87c2-6c19497346c1" />

#### Control Panel

<img width="1703" height="1278" alt="image" src="https://github.com/user-attachments/assets/f0bb7b30-31b2-4210-a8f0-85f9005a25a3" />


<img width="1703" height="1278" alt="image" src="https://github.com/user-attachments/assets/3a09ab7a-f3b4-453a-92bf-1acabd4f89ca" />

#### iPad Pro Dimensions

<img width="1366" height="1024" alt="image" src="https://github.com/user-attachments/assets/06505aec-4245-4a0b-9595-12fec0943d24" />

