### PR TITLE
chore: 修复prettier无法正常运行问题，新增项目级别 vscode 配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules/
 bak/
-.vscode
 users.json
 SyncContainerData.dat
 SyncContainerData.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  // 推送推荐安装插件列表（VS Code）
+  "recommendations": [
+    // Formatting: prettier
+    "esbenp.prettier-vscode",
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.insertSpaces": true,
+  "prettier.enable": true,
+  "prettier.configPath": ".prettierrc.js",
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+}

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "express": "^5.1.0",
     "google-protobuf": "^3.21.4",
     "long": "^5.3.2",
-    "prettier": "^3.6.2",
     "protobufjs": "^7.5.3",
     "socket.io": "^4.8.1",
     "winston": "^3.17.0"
   },
   "devDependencies": {
     "@yao-pkg/pkg": "^6.6.0",
+    "prettier": "^3.6.2",
     "protobufjs-cli": "^1.1.3"
   },
   "pkg": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       long:
         specifier: ^5.3.2
         version: 5.3.2
-      prettier:
-        specifier: ^3.6.2
-        version: 3.6.2
       protobufjs:
         specifier: ^7.5.3
         version: 7.5.3
@@ -39,6 +36,9 @@ importers:
       '@yao-pkg/pkg':
         specifier: ^6.6.0
         version: 6.6.0
+      prettier:
+        specifier: ^3.6.2
+        version: 3.6.2
       protobufjs-cli:
         specifier: ^1.1.3
         version: 1.1.3(protobufjs@7.5.3)


### PR DESCRIPTION
更新内容：
- [修复无法正常运行的问题，更新为开发环境依赖](https://github.com/dmlgzs/StarResonanceDamageCounter/commit/21430a27cc4ce36f2a2e5e1813624a68ed05aea4)
- [新增项目级别配置，如prettier路径，解析文件格式，推荐安装拓展列表等](https://github.com/dmlgzs/StarResonanceDamageCounter/commit/912e63a2d10c404e9eda374936cc2e685f3ed099)

注： `Prettier`是一款代码格式化工具，如果不能正常使用，请转到对应代码编辑器（vscode/cursor）的拓展商店安装推荐列表中列出的`Prettier`插件，然后重启代码编辑器再尝试