### PR TITLE
fix: set enemy HP to zero on death

### DIFF
--- a/algo/packet.js
+++ b/algo/packet.js
@@ -661,7 +661,17 @@ class PacketProcessor {
     _processSyncNearEntities(payloadBuffer) {
         const syncNearEntities = pb.SyncNearEntities.decode(payloadBuffer);
         // this.logger.debug(JSON.stringify(syncNearEntities, null, 2));
-
+        if (syncNearEntities.Disappear) {
+            for (const entity of syncNearEntities.Disappear) {
+                const entityUuid = entity.Uuid;
+                if (entityUuid && isUuidMonster(entityUuid)) {
+                    const entityUid = entityUuid.shiftRight(16).toNumber();
+                    if (entity.Type == pb.EDisappearType.EDisappearDead) {
+                        this.userDataManager.enemyCache.hp.set(entityUid, 0);
+                    }
+                }
+            }
+        }
         if (!syncNearEntities.Appear) return;
         for (const entity of syncNearEntities.Appear) {
             const entityUuid = entity.Uuid;


### PR DESCRIPTION
解决 #81 提到的`怪物死亡时服务器没推送对应的伤害数据`